### PR TITLE
Add loaded_revision method

### DIFF
--- a/lib/App/Config/Chronicle.pm
+++ b/lib/App/Config/Chronicle.pm
@@ -371,7 +371,9 @@ sub _save_dynamic {
 
 =head2 current_revision
 
-loads setting from chronicle reader and returns the last revision and drops them
+Loads setting from chronicle reader and returns the last revision
+
+It is more likely that you want C<loaded_revision> in regular use
 
 =cut
 
@@ -379,6 +381,22 @@ sub current_revision {
     my $self = shift;
     my $settings = $self->chronicle_reader->get($self->setting_namespace, $self->setting_name);
     return $settings->{_rev};
+}
+
+=head2 loaded_revision
+
+Returns the revision loaded and served by this instance
+
+This may not reflect the latest stored version in the Chronicle persistence.
+However, it is the revision of the data which will be returned when
+querying this instance
+
+=cut
+
+sub loaded_revision {
+    my $self = shift;
+
+    return $self->data_set->{version};
 }
 
 sub _build_data_set {

--- a/lib/App/Config/Chronicle.pm
+++ b/lib/App/Config/Chronicle.pm
@@ -305,12 +305,15 @@ sub _validate_key {
 
 check and load updated settings from chronicle db
 
+Checks at most every C<refresh_interval> unless forced with
+a truthy first argument
+
 =cut
 
 sub check_for_update {
-    my $self = shift;
+    my ($self, $force) = @_;
 
-    return unless $self->_has_refresh_interval_passed();
+    return unless $force or $self->_has_refresh_interval_passed();
     $self->_updated_at(Time::HiRes::time());
 
     # do check in Redis

--- a/lib/App/Config/Chronicle.pm
+++ b/lib/App/Config/Chronicle.pm
@@ -373,7 +373,7 @@ sub _save_dynamic {
 
 Loads setting from chronicle reader and returns the last revision
 
-It is more likely that you want C<loaded_revision> in regular use
+It is more likely that you want L</loaded_revision> in regular use
 
 =cut
 

--- a/lib/App/Config/Chronicle.pm
+++ b/lib/App/Config/Chronicle.pm
@@ -361,6 +361,11 @@ sub _save_dynamic {
     $settings->{_rev}   = Time::HiRes::time();
     $self->chronicle_writer->set($self->setting_namespace, $self->setting_name, $settings, Date::Utility->new);
 
+    # since we now have the most recent data, we better set the
+    # local version as well.
+    $self->data_set->{version} = $settings->{_rev};
+    $self->_updated_at($settings->{_rev});
+
     return 1;
 }
 

--- a/t/07_full_build.t
+++ b/t/07_full_build.t
@@ -39,8 +39,11 @@ $app_config->save_dynamic;
 # will not refresh as not enough time has passed
 $app_config2->check_for_update;
 is($app_config2->system->email, 'test@abc.com', "still have old value");
-
-sleep($app_config2->refresh_interval);
+{
+    no warnings 'redefine';
+    local *Time::HiRes::time = sub { return Time::HiRes::gettimeofday + $app_config2->refresh_interval };
+    $app_config2->check_for_update;
+}
 $app_config2->check_for_update;
 is($app_config2->system->email, 'test2@abc.com', "check_for_update worked");
 

--- a/t/07_full_build.t
+++ b/t/07_full_build.t
@@ -24,6 +24,7 @@ $app_config->save_dynamic;
 is_deeply($app_config->system->email, 'test@abc.com', "email is updated");
 my $new_revision = $app_config->current_revision;
 isnt($new_revision, $old_revision, "revision updated");
+is($app_config->loaded_revision, $new_revision, "Loaded revision matches current revision");
 my $app_config2 = App::Config::Chronicle->new(
     definition_yml   => "$Bin/test.yml",
     chronicle_reader => $chronicle_r,
@@ -39,12 +40,13 @@ $app_config->save_dynamic;
 # will not refresh as not enough time has passed
 $app_config2->check_for_update;
 is($app_config2->system->email, 'test@abc.com', "still have old value");
+cmp_ok($app_config2->loaded_revision, '<=',  $app_config2->current_revision, "Loaded revision is older than current revision");
 {
     no warnings 'redefine';
     local *Time::HiRes::time = sub { return Time::HiRes::gettimeofday + $app_config2->refresh_interval };
     $app_config2->check_for_update;
 }
-$app_config2->check_for_update;
 is($app_config2->system->email, 'test2@abc.com', "check_for_update worked");
+cmp_ok($app_config2->loaded_revision, '==',  $app_config2->current_revision, "Loaded revision once again current revision");
 
 done_testing;

--- a/t/08_new_api.t
+++ b/t/08_new_api.t
@@ -22,7 +22,11 @@ use constant {
 
 my $tick = 0;
 set_fixed_time($tick);
-*Time::HiRes::time = \&Test::MockTime::time;
+
+{
+    no warnings 'redefine';
+    *Time::HiRes::time = \&Test::MockTime::time;
+}
 
 subtest 'Global revision = 0' => sub {
     my $app_config = _new_app_config();


### PR DESCRIPTION
This is necessary to avoid some confusion around the meaning of `current_revision` and how it may be used.